### PR TITLE
BUG FIX: Ensure add patient works as expected

### DIFF
--- a/components/AddPatient.js
+++ b/components/AddPatient.js
@@ -16,8 +16,33 @@ export class AddPatientComponent extends React.Component {
     comments: ""
   };
 
+  addPatient = (
+    patientId,
+    comments,
+    user,
+    dispatchAddPatient,
+    completeDialog
+  ) => {
+    const newPatient = {
+      id: patientId,
+      comments,
+      timeStarted: Date.now(),
+      ...user
+    };
+
+    dispatchAddPatient(newPatient);
+    completeDialog();
+  };
+
   render() {
-    const { visible, patientId, user, hideDialog } = this.props;
+    const {
+      visible,
+      patientId,
+      user,
+      hideDialog,
+      dispatchAddPatient,
+      completeDialog
+    } = this.props;
     const { comments } = this.state;
     return (
       <Dialog visible={visible} onDismiss={hideDialog}>
@@ -40,12 +65,13 @@ export class AddPatientComponent extends React.Component {
           <Button onPress={hideDialog}>Cancel</Button>
           <Button
             onPress={() =>
-              addPatient({
-                id: patientId,
+              this.addPatient(
+                patientId,
                 comments,
-                timeStarted: Date.now(),
-                ...user
-              })
+                user,
+                dispatchAddPatient,
+                completeDialog
+              )
             }
             mode="contained"
           >
@@ -62,7 +88,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  addPatient: patient => dispatch(addPatient(patient))
+  dispatchAddPatient: patient => dispatch(addPatient(patient))
 });
 
 export const AddPatient = connect(


### PR DESCRIPTION
# Context

An issue was found where it was not possible to add new patients to the queue. This is a somewhat important aspect of the app, and could be found by trying to hit, "Add to queue" in the final modal dialog of the add patient flow.

# Solution
All the details of the patient were correctly captured - however the internal state of the application was not updated and the dialog was not called on to be closed. This was due to a naming collision between the [dispatcher](https://redux.js.org/api/store#a-id-dispatch-class-anchor-a-dispatchaction-dispatch) and an [action creator](https://redux.js.org/glossary#action) resulting in the dispatcher never being called.

To solve this we

1. Renamed the dispatcher to a non colliding name
1. Created a different function to handle both putting the patient object together and closing the dialog
1. Ensured the `completeDialog` function was available for the above to call

After some manual testing, things appear fine!

![](https://media.giphy.com/media/xTiTnzwJoXpg7gdONy/giphy.gif)