### PR TITLE
Send patient data

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -53,10 +53,6 @@ i18n.use(languageDetector).init({
 
   debug: true,
 
-  // cache: {
-  //   enabled: true
-  // },
-
   interpolation: {
     escapeValue: false // not needed for react as it does escape per default to prevent xss!
   }

--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -7,13 +7,13 @@ import { UserLoadingScreen } from "../screens/UserLoadingScreen";
 import { UserSignInStack } from "../screens/UserSignInScreen";
 import HomeScreen from "../screens/HomeScreen";
 import QrScreen from "../screens/QrScreen";
-import { SettingsComponent } from "../screens/Settings";
+import { SettingsScreen } from "../screens/Settings";
 
 const HomeStack = createStackNavigator(
   {
     Home: HomeScreen,
     Qr: QrScreen,
-    Settings: SettingsComponent
+    Settings: SettingsScreen
   },
   {
     initialRouteName: "Home"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-redux": "^6.0.0",
     "redux": "^4.0.1",
     "redux-persist": "^5.10.0",
+    "redux-thunk": "^2.3.0",
     "typesafe-actions": "^3.0.0"
   },
   "devDependencies": {

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -37,7 +37,7 @@ class HomeScreen extends React.Component {
 }
 const mapStateToProps = state => ({
   user: state.user,
-  patients: state.patients
+  patients: state.patients.queue
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/screens/QrScreen.js
+++ b/screens/QrScreen.js
@@ -19,6 +19,7 @@ const DisplayType = {
 };
 
 class QrScreen extends React.Component {
+  _isMounted = false;
   state = {
     hasCameraPermission: null,
     token: null,
@@ -27,10 +28,18 @@ class QrScreen extends React.Component {
   };
 
   async componentDidMount() {
+    this._isMounted = true;
     const { status }: { status: string } = await Permissions.askAsync(
       Permissions.CAMERA
     );
-    this.setState({ hasCameraPermission: status === "granted" });
+
+    if (this._isMounted) {
+      this.setState({ hasCameraPermission: status === "granted" });
+    }
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
   }
 
   hideDialog = () => this.setState({ display: DisplayType.Scanner });
@@ -121,7 +130,7 @@ class QrScreen extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  patients: state.patients,
+  patients: state.patients.queue,
   user: state.user
 });
 

--- a/screens/Settings.js
+++ b/screens/Settings.js
@@ -2,8 +2,10 @@ import * as React from "react";
 import { View, StyleSheet, KeyboardAvoidingView } from "react-native";
 import { Title, Divider, TextInput, Button } from "react-native-paper";
 import { LanguageSelector } from "../components/LanguageSelector";
+import { connect } from "react-redux";
+import { uploadPatients } from "../state/actions";
 
-export const SettingsComponent = ({}) => (
+export const SettingsComponent = ({ upload }) => (
   <View style={styles.container}>
     <View>
       <Title>Language</Title>
@@ -26,12 +28,21 @@ export const SettingsComponent = ({}) => (
         onChangeText={text => this.updateField(text, "facilityId")}
       />
 
-      <Button icon="save" mode="contained" onPress={this.signIn}>
-        Update
+      <Button icon="save" mode="contained" onPress={upload}>
+        Upload
       </Button>
     </KeyboardAvoidingView>
   </View>
 );
+
+const mapDispatchToProps = dispatch => ({
+  upload: () => dispatch(uploadPatients())
+});
+
+export const SettingsScreen = connect(
+  null,
+  mapDispatchToProps
+)(SettingsComponent);
 
 const styles = StyleSheet.create({
   container: {

--- a/screens/Settings.js
+++ b/screens/Settings.js
@@ -3,44 +3,66 @@ import { View, StyleSheet, KeyboardAvoidingView } from "react-native";
 import { Title, Divider, TextInput, Button } from "react-native-paper";
 import { LanguageSelector } from "../components/LanguageSelector";
 import { connect } from "react-redux";
-import { uploadPatients } from "../state/actions";
+import { uploadPatients, updateServerConfiguration } from "../state/actions";
 
-export const SettingsComponent = ({ upload }) => (
-  <View style={styles.container}>
-    <View>
-      <Title>Language</Title>
-      <LanguageSelector />
-    </View>
-    <Divider style={{ margin: 24 }} />
-    <KeyboardAvoidingView behavior="padding" enabled>
-      <Title>Server details</Title>
-      <TextInput
-        mode="outlined"
-        style={styles.input}
-        label="Address"
-        onChangeText={text => this.updateField(text, "name")}
-      />
+export class SettingsComponent extends React.Component {
+  state = { server: this.props.server };
 
-      <TextInput
-        mode="outlined"
-        style={styles.input}
-        label="Password"
-        onChangeText={text => this.updateField(text, "facilityId")}
-      />
+  render() {
+    const { upload, updateServer } = this.props;
+    const { server } = this.state;
 
-      <Button icon="save" mode="contained" onPress={upload}>
-        Upload
-      </Button>
-    </KeyboardAvoidingView>
-  </View>
-);
+    return (
+      <View style={styles.container}>
+        <View>
+          <Title>Language</Title>
+          <LanguageSelector />
+        </View>
+        <Divider style={{ margin: 24 }} />
+        <KeyboardAvoidingView behavior="padding" enabled>
+          <Title>Server details</Title>
+          <TextInput
+            mode="outlined"
+            style={styles.input}
+            label="Address"
+            value={server.address}
+            onChangeText={text =>
+              this.setState({ server: { ...server, address: text } })
+            }
+            onBlur={() => updateServer(this.state.server)}
+          />
+
+          <TextInput
+            mode="outlined"
+            style={styles.input}
+            label="Password"
+            value={server.password}
+            onChangeText={text =>
+              this.setState({ server: { ...server, password: text } })
+            }
+            onBlur={() => updateServer(this.state.server)}
+          />
+
+          <Button icon="save" mode="contained" onPress={upload}>
+            Upload
+          </Button>
+        </KeyboardAvoidingView>
+      </View>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  server: state.server
+});
 
 const mapDispatchToProps = dispatch => ({
-  upload: () => dispatch(uploadPatients())
+  upload: () => dispatch(uploadPatients()),
+  updateServer: config => dispatch(updateServerConfiguration(config))
 });
 
 export const SettingsScreen = connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps
 )(SettingsComponent);
 

--- a/screens/UserSignInScreen.js
+++ b/screens/UserSignInScreen.js
@@ -101,7 +101,7 @@ export class UserSignInScreen extends React.Component {
   }
 }
 
-const mapDispactToProps = dispatch => ({
+const mapDispatchToProps = dispatch => ({
   setUser: user => dispatch(setUser(user))
 });
 
@@ -109,7 +109,7 @@ export const UserSignInStack = createStackNavigator({
   UserSignIn: withNamespaces(["signIn"], { wait: true })(
     connect(
       null,
-      mapDispactToProps
+      mapDispatchToProps
     )(UserSignInScreen)
   )
 });

--- a/state/actions.js
+++ b/state/actions.js
@@ -30,12 +30,21 @@ export const sendPatientsFailure = error => ({
   error
 });
 
+export const updateServerConfiguration = config => ({
+  type: "UPDATE_SERVER_CONFIGURATION",
+  config
+});
+
 export const uploadPatients = () => {
   return (dispatch, getState) => {
+    const { patients, server } = getState();
     dispatch(sendPatientsRequest());
-    fetch("https://postman-echo.com/post", {
+    fetch(server.address, {
       method: "POST",
-      body: JSON.stringify(getState().patients.queue)
+      headers: {
+        Authorization: server.password
+      },
+      body: JSON.stringify(patients.queue)
     }).then(response => {
       if (response.status === 200) {
         dispatch(sendPatientsSuccess());

--- a/state/actions.js
+++ b/state/actions.js
@@ -16,3 +16,30 @@ export const setUser = payload => ({
 export const clearUser = () => ({
   type: "CLEAR_USER"
 });
+
+export const sendPatientsRequest = () => ({
+  type: "SEND_PATIENTS_REQUEST"
+});
+
+export const sendPatientsSuccess = () => ({
+  type: "SEND_PATIENTS_SUCCESS"
+});
+
+export const sendPatientsFailure = error => ({
+  type: "SEND_PATIENTS_FAILURE",
+  error
+});
+
+export const uploadPatients = () => {
+  return (dispatch, getState) => {
+    dispatch(sendPatientsRequest());
+    fetch("https://postman-echo.com/post", {
+      method: "POST",
+      body: JSON.stringify(getState().patients.queue)
+    }).then(response => {
+      if (response.status === 200) {
+        dispatch(sendPatientsSuccess());
+      }
+    });
+  };
+};

--- a/state/configureStore.js
+++ b/state/configureStore.js
@@ -1,7 +1,7 @@
-import { createStore } from "redux";
+import { createStore, applyMiddleware } from "redux";
 import { persistStore, persistReducer } from "redux-persist";
+import thunk from "redux-thunk";
 import storage from "redux-persist/lib/storage"; // defaults to localStorage for web and AsyncStorage for react-native
-
 import { rootReducer } from "./reducers";
 
 const persistConfig = {
@@ -12,7 +12,7 @@ const persistConfig = {
 const persistedReducer = persistReducer(persistConfig, rootReducer);
 
 export default () => {
-  let store = createStore(persistedReducer);
+  let store = createStore(persistedReducer, applyMiddleware(thunk));
   let persistor = persistStore(store);
   return { store, persistor };
 };

--- a/state/reducers.js
+++ b/state/reducers.js
@@ -35,15 +35,14 @@ export const rootReducer = combineReducers({
   },
   server: (
     state = {
-      address: "",
-      password: "",
-      isFetching: false
+      address: "https://postman-echo.com/post",
+      password: "test"
     },
     action
   ) => {
     switch (action.type) {
-      case "UPDATE_CONFIGURATION":
-        return { ...state, password: action.password };
+      case "UPDATE_SERVER_CONFIGURATION":
+        return action.config;
       default:
         return state;
     }

--- a/state/reducers.js
+++ b/state/reducers.js
@@ -1,15 +1,24 @@
 import { combineReducers } from "redux";
 
+const patientsInitialState = { queue: [], isFetching: false };
+
 export const rootReducer = combineReducers({
-  patients: (state = [], action) => {
+  patients: (state = patientsInitialState, action) => {
     switch (action.type) {
       case "ADD_PATIENT":
-        return [...state, action.payload];
+        return { ...state, queue: [...state.queue, action.payload] };
       case "EDIT_PATIENT":
-        return state.map(p => {
-          if (p.id !== action.payload.id) return p;
-          return { ...p, ...action.payload };
-        });
+        return {
+          ...state,
+          queue: state.queue.map(p => {
+            if (p.id !== action.payload.id) return p;
+            return { ...p, ...action.payload };
+          })
+        };
+      case "SEND_PATIENTS_REQUEST":
+        return { ...state, isFetching: true };
+      case "SEND_PATIENTS_SUCCESS":
+        return { ...state, queue: [], isFetching: false };
       default:
         return state;
     }
@@ -20,6 +29,21 @@ export const rootReducer = combineReducers({
         return action.payload;
       case "CLEAR_USER":
         return null;
+      default:
+        return state;
+    }
+  },
+  server: (
+    state = {
+      address: "",
+      password: "",
+      isFetching: false
+    },
+    action
+  ) => {
+    switch (action.type) {
+      case "UPDATE_CONFIGURATION":
+        return { ...state, password: action.password };
       default:
         return state;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6142,7 +6142,7 @@ react-native-gesture-handler@~1.0.14:
     invariant "^2.2.2"
     prop-types "^15.5.10"
 
-react-native-maps@*, "react-native-maps@github:expo/react-native-maps#v0.22.1-exp.0":
+react-native-maps@*, react-native-maps@expo/react-native-maps#v0.22.1-exp.0:
   version "0.22.1"
   resolved "https://codeload.github.com/expo/react-native-maps/tar.gz/e6f98ff7272e5d0a7fe974a41f28593af2d77bb2"
 
@@ -6468,6 +6468,11 @@ redux-persist@^5.10.0:
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-5.10.0.tgz#5d8d802c5571e55924efc1c3a9b23575283be62b"
   integrity sha512-sSJAzNq7zka3qVHKce1hbvqf0Vf5DuTVm7dr4GtsqQVOexnrvbV47RWFiPxQ8fscnyiuWyD2O92DOxPl0tGCRg==
+
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
 
 redux@^4.0.0, redux@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
This PR allows the user to send patient data from the "Settings" screen.

Patient data is then bundled up and sent to an address. If that address responds with a HTTP status code of `200`, the patient data is cleared

### Solution
We use redux-thunk to allow our state to be updated asynchronously onto our redux store. Before we start the request we tell the application we're about to send off data, in case we want to show a spinner or anything else that gives the user pause.

Once the response comes back positively, we cease the spinner and clean up our data


### Enhancements
We should be able to 
- [ ] automatically upload completed patients
- [ ] do an end-to-end test with MSSQL
- [ ] stop folks wiping patients when hitting `update`